### PR TITLE
launcher: Fix ambiguous token setup instructions

### DIFF
--- a/launcher
+++ b/launcher
@@ -9,7 +9,7 @@ if ! [ -e "$config_file" ]; then
 #host = matterhorn.yourhost.org
 #team = the default team
 
-# Set with: snap run --shell matterhorn -c 'secret-tool store --label="\$SNAP_NAME" \$SNAP_NAME <token>
+# Set with: snap run --shell matterhorn -c 'secret-tool store --label="\$SNAP_NAME" \$SNAP_NAME token
 #tokencmd = secret-tool lookup $SNAP_NAME token
 
 urlOpenCommand = xdg-open
@@ -28,7 +28,8 @@ EOF
     echo
     echo "Call this command to setup an access token:"
     echo "  snap run --shell matterhorn -c \\"
-    echo "    'secret-tool store --label=\"\$SNAP_NAME\" \$SNAP_NAME <token>'"
+    echo "    'secret-tool store --label=\"\$SNAP_NAME\" \$SNAP_NAME token'"
+    echo "Paste the token when prompted."
     echo
     echo "Press any key to run $SNAP_NAME..."
     read -n1 foo


### PR DESCRIPTION
The previous instructions suggested that the token should be part of the command line arguments, while it should actually be passed as input.